### PR TITLE
Make sure resources menu stays open when clicked

### DIFF
--- a/assets/pages/marketing.coffee
+++ b/assets/pages/marketing.coffee
@@ -4,7 +4,12 @@ ahoy.trackAll()
 
 $(document).on 'click', '.header__menu-resource-dropdown', (e) ->
   $(@).toggle()
-  $(@).parent().attr 'aria-expanded', @is(':visible')
+  $(@).parent().attr 'aria-expanded', $(@).is(':visible')
+
+$(document).on 'click', '.header__resources-dropdown', (e) ->
+  menu = $('.header__resources-dropdown-menu')
+  menu.css('display', if menu.css('display') == 'block' then 'none' else 'block')
+  $(@).attr 'aria-expanded', menu.is(':visible')
 
 $(document).on 'click', '.header__menu-collapsed-button', (e) ->
   menu = $('.header__menu')


### PR DESCRIPTION
Unfortunately this fix means that if you're hovering over the menu and it is open then clicking it closes the menu...not 100% sure how it was working prior to the extraction...

https://github.com/loomio/loomio/issues/3847