### PR TITLE
Put Learn after features and plans in navigation menu

### DIFF
--- a/app/views/layouts/pages.html.haml
+++ b/app/views/layouts/pages.html.haml
@@ -27,9 +27,9 @@
         %a{href: "/"}
           = image_tag 'lance/images/loomio-logo-80h.png', class: 'nav__logo'
         .nav__spacer
-        %a.nav__link.nav__learn-link{href: "https://www.loomio.school/"}= t(:"navigation.learn")
         %a.nav__link.nav__features-link{href: "/#features"}= t(:"navigation.features")
         %a.nav__link.nav__pricing-link{href: "/pricing"}= t(:"navigation.pricing")
+        %a.nav__link.nav__learn-link{href: "https://www.loomio.school/"}= t(:"navigation.learn")
         %a.nav__link.nav__sign-in-link{href: "/users/sign_in/"}= t(:"navigation.login")
 
     = yield

--- a/config/locales/marketing.en.yml
+++ b/config/locales/marketing.en.yml
@@ -49,6 +49,7 @@ en:
     receive_updates_subtext: "Reach people where they are. Everyone on slack will receive updates about important events as they happen."
     vote_instantly: "Vote instantly from Slack"
     vote_instantly_subtext: "No need to leave your chat window to make your voice heard; simply click a button and you're done!"
+    get_started: Get started
     on_paid_plan: "The LoomioBot integration is available for groups on a Gold plan or higher"
 
   pricing_page:


### PR DESCRIPTION
I think it makes more sense to learn about the solution before diving into facilitation resources and Loomio help, the menu should reflect this future user journey...